### PR TITLE
fix: Update database query execution in `fetch_routes.py` to use `execute`

### DIFF
--- a/src/API/routes/fetch_routes.py
+++ b/src/API/routes/fetch_routes.py
@@ -42,7 +42,7 @@ async def get_procedure_names_and_entities():
                 GROUP BY p.id, p.name
                 ORDER BY p.name
                 """
-                cur = await conn.execute_query(query=query)
+                cur = await conn.execute(query=query)
                 results = await cur.fetchall()
 
                 # --- START OF MODIFICATION ---
@@ -196,7 +196,7 @@ async def get_one_graph_version_detail(
                 FROM graph g
                 WHERE g.procedure_id = %s AND g.entity = %s AND g.id = %s
                 """
-                cur = await conn.execute_query(
+                cur = await conn.execute(
                     query=query, params=(procedure_id, entity, graph_id)
                 )
 


### PR DESCRIPTION
- After DB changes `execute_query` is deprecated and some instances of calling this function still remained