### PR TITLE
refactor/fix(API): Fix eventloop error with Asyncio. Add `extracted_at` field to ProcedureItem response

### DIFF
--- a/src/API/main.py
+++ b/src/API/main.py
@@ -1,8 +1,13 @@
+import asyncio
 import sys
 from pathlib import Path
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
+
+# Configure Windows-compatible event loop policy for async PostgreSQL
+if sys.platform.startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 # Add parent directory to Python path
 sys.path.append(str(Path(__file__).parents[2].resolve()))

--- a/src/API/pydantic_models.py
+++ b/src/API/pydantic_models.py
@@ -36,8 +36,9 @@ class ProcedureItem(BaseModel):
         document_id: UUID of the source document
         document_name: Name of the source document
         graph: JSON representation of the procedure graph
+        created_at: Timestamp of graph creation
         accuracy: Confidence score of the procedure
-        extracted_at: Timestamp of extraction
+        extracted_at: Timestamp of procedure extraction
         extraction_method: Method used to extract the graph
         model_name: Name of the model used
         entity: Type of network entity (e.g., UE, AMF)
@@ -54,6 +55,7 @@ class ProcedureItem(BaseModel):
     graph: Graph
     accuracy: float
     extracted_at: datetime
+    created_at: datetime
     extraction_method: str
     model_name: str
     entity: str

--- a/src/API/routes/fetch_routes.py
+++ b/src/API/routes/fetch_routes.py
@@ -77,7 +77,7 @@ async def get_latest_graph_by_procedure_id_and_entity(procedure_id: UUID, entity
                 SELECT 
                     g.id as graph_id, g.entity, g.extracted_data, g.model_name, g.accuracy, g.version,
                     g.created_at, g.status, g.extraction_method, g.commit_title, g.commit_message, g.entity,
-                    p.name as procedure_name,p.id as procedure_id, p.retrieved_top_sections,
+                    p.name as procedure_name,p.id as procedure_id, p.retrieved_top_sections, p.extracted_at,
                     d.id as document_id, d.name as document_name
                 FROM graph g
                 JOIN procedure p ON g.procedure_id = p.id
@@ -111,9 +111,10 @@ async def get_latest_graph_by_procedure_id_and_entity(procedure_id: UUID, entity
                     procedure_id=procedure_id,
                     document_id=result["document_id"],
                     document_name=result["document_name"],
-                    graph=result["extracted_data"],  # Only one graph now
+                    graph=result["extracted_data"],
+                    created_at=result["created_at"],
                     accuracy=result["accuracy"],
-                    extracted_at=result["created_at"],
+                    extracted_at=result["extracted_at"],
                     model_name=result["model_name"],
                     extraction_method=result["extraction_method"],
                     entity=result["entity"],


### PR DESCRIPTION
- `extracted_at` is the date of which the original procedure was extracted
- `created_at` is the date of which that specific graph was created. (previously we called it edited_at)
- Fixed the error when running API and requesting a route with Async functions